### PR TITLE
Update goversion to ex-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
           goos: ${{ matrix.goos }}
           project_path: "./cmd/helmwave"
           goarch: ${{ matrix.goarch }}
+          goversion: "1.15.8"
+


### PR DESCRIPTION
By default wangyoucao577/go-release-action uses 1.14, which is pretty old - https://github.com/wangyoucao577/go-release-action/blob/master/setup-go.sh#L3