### PR TITLE
Fix release workflow for draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   releases-matrix:


### PR DESCRIPTION
`created` type stands for created tag
`published` type - published release