### PR TITLE
Refactor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
 ---
-name: Bug report about: Create a report to help us improve title: ''
-labels: bug assignees: ''
+name: Bug report about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,21 +1,20 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: bug
-assignees: ''
-
+about: Create a report to help us improve title: ''
+labels: bug assignees: ''
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 ** General info (please complete the following information):**
- - OS: [e.g. linux, windows, macOS]
- - Helmwave Version [e.g. 0.4.0]
+
+- OS: [e.g. linux, windows, macOS]
+- Helmwave Version [e.g. 0.4.0]
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 0. Show your helmwave.yml.tpl
 1. Show your helmwave.yml
 2. Show yout Planfile
@@ -27,7 +26,6 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
-
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,5 @@
 ---
-name: Bug report
-about: Create a report to help us improve title: ''
+name: Bug report about: Create a report to help us improve title: ''
 labels: bug assignees: ''
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-The 🌊 HelmWave project accepts contributions via GitHub pull requests. 
+The 🌊 HelmWave project accepts contributions via GitHub pull requests. \
 This document outlines the process to help get your contribution accepted.
 
 ## Milestones

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS builder
+FROM golang:1.15-alpine3.13 AS builder
 
 LABEL maintainer="helmwave+zhilyaev.dmitriy@gmail.com"
 LABEL name="helmwave"
@@ -6,7 +6,7 @@ LABEL name="helmwave"
 # enable Go modules support
 ENV GO111MODULE=on
 
-WORKDIR $GOPATH/src/github.com/zhilyaev/helmwave
+WORKDIR helmwave
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -14,9 +14,9 @@ RUN go mod download
 # Copy src code from the host and compile it
 COPY cmd cmd
 COPY pkg pkg
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o /helmwave github.com/zhilyaev/helmwave/cmd/helmwave
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /helmwave ./cmd/helmwave
 
-FROM alpine:3.13.1
+FROM alpine:3.13
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /helmwave /bin
 ENTRYPOINT ["/bin/helmwave"]

--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@
 </p>
 
 
-🌊 HelmWave is **[helm](https://github.com/helm/helm/)-native** tool for deploy your Helm Charts via **GitOps**. HelmWave is like docker-compose for helm.
-
-
+🌊 HelmWave is **[helm](https://github.com/helm/helm/)-native** tool for deploy your Helm Charts via **GitOps**.
+HelmWave is like docker-compose for helm.
 
 - Keep a directory of chart value files and maintain changes in version control.
 - Apply CI/CD to configuration changes
 - Template values
 - Aggregate your application
 
-
 ## Comparison
- 🚀 Features  | 🌊 HelmWave   | helmfile 
+
+🚀 Features  | 🌊 HelmWave   | helmfile
 -------------| :------------:|:-----------:
 Docker | ![Docker Image Size helmwave (latest by date)](https://img.shields.io/docker/image-size/diamon/helmwave) | ![Docker Image Size helmfile (latest by date)](https://img.shields.io/docker/image-size/chatwork/helmfile)
 [Kubedog](https://github.com/werf/kubedog) |✅|❌
@@ -41,6 +40,7 @@ Sprig | ✅|✅
 Call helm | via Golang Module | Shell Executor
 
 ## Todo:
+
 - buy a domain
 - make docs
 
@@ -52,6 +52,7 @@ Call helm | via Golang Module | Shell Executor
 $ wget -c https://github.com/zhilyaev/helmwave/releases/download/0.8.3/helmwave-0.8.3-linux-amd64.tar.gz -O - | tar -xz
 $ mv helmwave /usr/local/bin/
 ```
+
 ### Install with go ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/zhilyaev/helmwave)
 
 ```bash
@@ -111,7 +112,8 @@ releases:
 $ helmwave deploy
 ```
 
-Congratulations! 
+Congratulations!
+
 ```shell script
 $ helm list -n my-namespace
 NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
@@ -131,10 +133,12 @@ redis-b-slave-1    1/1     Running   0          51s
 ## Articles
 
 ### RU
+
 - [HelmWave v0.5.0 – GitOps для твоего Kubernetes](https://habr.com/ru/post/532596/)
--  HelmWave v0.8.3 – Kubedog рядом
+- HelmWave v0.8.3 – Kubedog рядом
 
 ## EN
+
 - WIP
 
 ## [Documentation](https://zhilyaev.github.io/helmwave/)
@@ -157,17 +161,22 @@ redis-b-slave-1    1/1     Running   0          51s
 
 Defines a condition when helmwave should stop tracking of the resource:
 
-- `WaitUntilResourceReady` (default) — the entire deployment process would monitor and wait for the readiness of the resource having this annotation. Since this mode is enabled by default, the deployment process would wait for all resources to be ready. 
+- `WaitUntilResourceReady` (default) — the entire deployment process would monitor and wait for the readiness of the
+  resource having this annotation. Since this mode is enabled by default, the deployment process would wait for all
+  resources to be ready.
 - `NonBlocking` — the resource is tracked only if there are other resources that are not yet ready.
 
 #### helmwave.dev/fail-mode
 
-Defines how helmwave will handle a resource failure condition which occured after failures threshold has been reached for the resource during deploy process:
+Defines how helmwave will handle a resource failure condition which occured after failures threshold has been reached
+for the resource during deploy process:
 
-- `FailWholeDeployProcessImmediately` (default) — the entire deploy process will fail with an error if an error occurs for some resource.
-- `HopeUntilEndOfDeployProcess` — when an error occurred for the resource, set this resource into the “hope” mode, and continue tracking other resources. If all remained resources are ready or in the “hope” mode, transit the resource back to “normal” and fail the whole deploy process if an error for this resource occurs once again.
+- `FailWholeDeployProcessImmediately` (default) — the entire deploy process will fail with an error if an error occurs
+  for some resource.
+- `HopeUntilEndOfDeployProcess` — when an error occurred for the resource, set this resource into the “hope” mode, and
+  continue tracking other resources. If all remained resources are ready or in the “hope” mode, transit the resource
+  back to “normal” and fail the whole deploy process if an error for this resource occurs once again.
 - `IgnoreAndContinueDeployProcess` — resource errors do not affect the deployment process.
-
 
 #### helmwave.dev/failures-allowed-per-replica
 
@@ -310,6 +319,7 @@ releases:
 ```
 
 This command will render `helmwave.yml.tpl` to `helmwave.yml`
+
 ```shell script
 $ export NS=stage
 $ export CI_PROJECT_NAME=my-project
@@ -349,7 +359,7 @@ This command will generate helmwave.plan.
 
 <details>
   <summary>helmwave.plan looks like</summary>
-  
+
   ```yaml
   project: my-project
   version: 0.8.3
@@ -435,26 +445,31 @@ This command will generate helmwave.plan.
       postrenderer: null
       disableopenapivalidation: false
   ```
+
 </details>
 
 ## 📄 Templating
+
 HelmWave uses [Go templates](https://godoc.org/text/template) for templating.
 
-Helmwave supports all built-in functions, [Sprig library](https://godoc.org/github.com/Masterminds/sprig), and several advanced functions:
+Helmwave supports all built-in functions, [Sprig library](https://godoc.org/github.com/Masterminds/sprig), and several
+advanced functions:
+
 - `toYaml` marshals a map into a string
 - `fromYaml` reads a golang string and generates a map
 - `readFile` get file as string
 - `hasKey` get true if field is exists
 - `get` (Sprig's original `get` is available as `sprigGet`)
 - `setValueAtPath` PATH NEW_VALUE traverses a golang map, replaces the value at the PATH with NEW_VALUE
-- `requiredEnv` The requiredEnv function allows you to declare a particular environment variable as required for template rendering. If the environment variable is unset or empty, the template rendering will fail with an error message.
-
+- `requiredEnv` The requiredEnv function allows you to declare a particular environment variable as required for
+  template rendering. If the environment variable is unset or empty, the template rendering will fail with an error
+  message.
 
 #### readFile
 
 <details>
   <summary>my-releases.yml</summary>
-  
+
   ```yaml
 releases:
   - name: redis
@@ -462,11 +477,12 @@ releases:
   - name: memcached
     repo: bitnami
   ```
+
 </details>
 
 <details>
   <summary>helmwave.yml.tpl</summary>
-  
+
   ```yaml
   project: my
   version: 0.8.3
@@ -491,7 +507,7 @@ releases:
     {{- end }}
   {{- end }}
   ``` 
-  
+
 </details>
 
 ```bash
@@ -500,7 +516,7 @@ $ helmwave yml
 
 <details>
   <summary>helmwave.yml</summary>
-  
+
   ```yaml
   project: my
   version: 0.8.3
@@ -522,7 +538,7 @@ $ helmwave yml
       options:
         <<: *global
   ``` 
-  
+
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ redis-b-slave-1    1/1     Running   0          51s
 
 ### Annotations
 
-> inspired by [helmwave annotations](https://helmwave.io/documentation/reference/deploy_annotations.html)
+> inspired by [werf annotations](https://werf.io/documentation/reference/deploy_annotations.html)
 
 ```yaml
   template:
@@ -171,40 +171,73 @@ Defines how helmwave will handle a resource failure condition which occured afte
 
 #### helmwave.dev/failures-allowed-per-replica
 
-By default, one error per replica is allowed before considering the whole deployment process unsuccessful. This setting defines a threshold of failures after which resource will be considered as failed and helmwave will handle this situation using fail mode.
+By default, one error per replica is allowed before considering the whole deployment process unsuccessful. This setting
+defines a threshold of failures after which resource will be considered as failed and helmwave will handle this
+situation using fail mode.
 
 - NUMBER
 
 #### helmwave.dev/log-regex
 
-Defines a Re2 regex template that applies to all logs of all containers of all Pods owned by a resource with this annotation. helmwave would show only those log lines that fit the specified regex template. By default, helmwave shows all log lines.
+Defines a Re2 regex template that applies to all logs of all containers of all Pods owned by a resource with this
+annotation. helmwave would show only those log lines that fit the specified regex template. By default, helmwave shows
+all log lines.
+
+- RE2_REGEX
+
+#### helmwave.dev/log-regex-for-{container}
+
+Defines a Re2 regex template that applies to all logs of specified container of all Pods owned by a resource with this
+annotation. helmwave would show only those log lines that fit the specified regex template. By default, helmwave shows
+all log lines.
 
 - RE2_REGEX
 
 #### helmwave.dev/skip-logs
 
-Set to "true" to turn off printing logs of all containers of all Pods owned by a resource with this annotation. This annotation is disabled by default.
+Set to "true" to turn off printing logs of all containers of all Pods owned by a resource with this annotation. This
+annotation is disabled by default.
 
 - "true"|"false"
 
+#### helmwave.dev/skip-logs-for-containers
+
+Turn off printing logs of specified containers of all Pods owned by a resource with this annotation. This annotation is
+disabled by default.
+
+- string with `,` as a separator
+
+#### helmwave.dev/show-logs-only-for-containers
+
+Turn off printing logs of all containers except specified of all Pods owned by a resource with this annotation. This
+annotation is disabled by default.
+
+- string with `,` as a separator
+
 #### helmwave.dev/show-service-messages
 
-Set to "true" to enable additional real-time debugging info (including Kubernetes events) for a resource during tracking. By default, helmwave would show these service messages only if the resource has failed the entire deploy process.
+Set to "true" to enable additional real-time debugging info (including Kubernetes events) for a resource during
+tracking. By default, helmwave would show these service messages only if the resource has failed the entire deploy
+process.
 
 - "true"|"false"
 
 ### Examples
-  - [How to pass `image.tag` to release?](docs/examples/CI_COMMIT_TAG/README.md)
-  - [How to pass `podAnnotations.gitCommit` to release?](docs/examples/CI_COMMIT_SHORT_SHA/README.md)
+
+- [How to pass `image.tag` to release?](docs/examples/CI_COMMIT_TAG/README.md)
+- [How to pass `podAnnotations.gitCommit` to release?](docs/examples/CI_COMMIT_SHORT_SHA/README.md)
   - [How to use environments for your release?](docs/examples/CI_ENVIRONMENT_NAME/README.md)
 
 ### [🔰 Store](docs/store.md)
-It allows pass you custom values to render release. 
+
+It allows pass you custom values to render release.
 
 ### [🔰 Tags](docs/tags.md)
+
 Use tags for choose specific releases
 
 ### [🧬 Full `helmwave.yml` config](docs/helmwave.yml.md)
+
 All Options
 
 ## 🛠 CLI Reference

--- a/docs/examples/CI_COMMIT_TAG/README.md
+++ b/docs/examples/CI_COMMIT_TAG/README.md
@@ -10,8 +10,6 @@ Project Structure
 
 ```
 
-
-
 ```yaml
 {% include_relative helmwave.yml.tpl %}
 ```

--- a/docs/examples/CI_ENVIRONMENT_NAME/README.md
+++ b/docs/examples/CI_ENVIRONMENT_NAME/README.md
@@ -31,6 +31,7 @@ releases:
 ```
 
 #### `_.yml`
+
 ```yaml
 image:
   tag: {{ env "CI_COMMIT_TAG" }}
@@ -39,13 +40,14 @@ podAnnotations:
   gitCommit: {{ requiredEnv "CI_COMMIT_SHORT_SHA" | quote }}
 ```
 
-
 #### `prod.yml`
+
 ```yaml
 replicaCount: 6
 ```
 
 #### `stage.yml`
+
 ```yaml
 replicaCount: 2
 ```

--- a/docs/helmwave.yml.md
+++ b/docs/helmwave.yml.md
@@ -1,6 +1,7 @@
 # 🧬 Full Configuration
 
 ## General
+
 ```yaml
 project: my-project
 version: 0.5.0
@@ -23,7 +24,6 @@ repositories:
   insecureskiptlsverify: false
   force: false
 ```
-
 
 ## 🛥 Release
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,19 @@
 # [Documentation](https://zhilyaev.github.io/helmwave/)
 
-
 ## Examples
-  - [How to pass `image.tag` to release?](examples/CI_COMMIT_TAG/README.md)
-  - [How to pass `podAnnotations.gitCommit` to release?](examples/CI_COMMIT_SHORT_SHA/README.md)
-  - [How to use environments for your release?](examples/CI_ENVIRONMENT_NAME/README.md)
+
+- [How to pass `image.tag` to release?](examples/CI_COMMIT_TAG/README.md)
+- [How to pass `podAnnotations.gitCommit` to release?](examples/CI_COMMIT_SHORT_SHA/README.md)
+- [How to use environments for your release?](examples/CI_ENVIRONMENT_NAME/README.md)
 
 ## [🔰 Store](store.md)
-It allows pass you custom values to render release. 
+
+It allows pass you custom values to render release.
 
 ## [🔰 Tags](tags.md)
+
 Use tags for choose specific releases
 
 ## [🧬 Full `helmwave.yml` config](helmwave.yml.md)
+
 All Options

--- a/docs/store.md
+++ b/docs/store.md
@@ -1,5 +1,6 @@
-# 🔰 Store 
-It allows pass you custom values to render release. 
+# 🔰 Store
+
+It allows pass you custom values to render release.
 
 #### `helmwave.yml`:
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -57,15 +57,11 @@ This command will deploy only `redis-a` & `memcached-a`
 $ helmwave -t a deploy
 ```
 
-
-
 This command will deploy only `redis-a` & `redis-b`
 
 ```shell script
 $ helmwave -t redis deploy
 ```
-
-
 
 This command will deploy only `redis-b`
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.0
+	github.com/bombsimon/logrusr v1.0.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/gofrs/flock v0.8.0
 	github.com/huandu/xstrings v1.3.2 // indirect
@@ -17,5 +18,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.5.0
 	k8s.io/apimachinery v0.20.4
+	k8s.io/klog/v2 v2.4.0
 	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/fatih/color v1.9.0 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gofrs/flock v0.8.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bombsimon/logrusr v1.0.0 h1:CTCkURYAt5nhCCnKH9eLShYayj2/8Kn/4Qg3QfiU+Ro=
+github.com/bombsimon/logrusr v1.0.0/go.mod h1:Jq0nHtvxabKE5EMwAAdgTaz7dfWE8C4i11NOltxGQpc=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
@@ -883,6 +885,7 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=

--- a/pkg/helmwave/logger.go
+++ b/pkg/helmwave/logger.go
@@ -3,6 +3,7 @@ package helmwave
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zhilyaev/helmwave/pkg/formatter"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 type Log struct {
@@ -13,6 +14,12 @@ type Log struct {
 }
 
 func (c *Config) InitLogger() error {
+	// Skip various low-level k8s client errors
+	// There are a lot of context deadline errors being logged
+	utilruntime.ErrorHandlers = []func(error){
+		logKubernetesClientError,
+	}
+
 	c.InitLoggerFormat()
 	return c.InitLoggerLevel()
 }
@@ -48,4 +55,8 @@ func (c *Config) InitLoggerFormat() {
 		})
 	}
 
+}
+
+func logKubernetesClientError(err error) {
+	log.Debugf("kubernetes client error %q", err.Error())
 }

--- a/pkg/helmwave/logger.go
+++ b/pkg/helmwave/logger.go
@@ -1,9 +1,11 @@
 package helmwave
 
 import (
+	"github.com/bombsimon/logrusr"
 	log "github.com/sirupsen/logrus"
 	"github.com/zhilyaev/helmwave/pkg/formatter"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 )
 
 type Log struct {
@@ -19,6 +21,7 @@ func (c *Config) InitLogger() error {
 	utilruntime.ErrorHandlers = []func(error){
 		logKubernetesClientError,
 	}
+	klog.SetLogger(logrusr.NewLogger(log.StandardLogger()))
 
 	c.InitLoggerFormat()
 	return c.InitLoggerLevel()

--- a/pkg/helmwave/logger.go
+++ b/pkg/helmwave/logger.go
@@ -4,7 +4,6 @@ import (
 	"github.com/bombsimon/logrusr"
 	log "github.com/sirupsen/logrus"
 	"github.com/zhilyaev/helmwave/pkg/formatter"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 )
 
@@ -16,11 +15,7 @@ type Log struct {
 }
 
 func (c *Config) InitLogger() error {
-	// Skip various low-level k8s client errors
-	// There are a lot of context deadline errors being logged
-	utilruntime.ErrorHandlers = []func(error){
-		logKubernetesClientError,
-	}
+	// Override klog base logger to handle correctly log levels
 	klog.SetLogger(logrusr.NewLogger(log.StandardLogger()))
 
 	c.InitLoggerFormat()

--- a/pkg/helmwave/logger.go
+++ b/pkg/helmwave/logger.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bombsimon/logrusr"
 	log "github.com/sirupsen/logrus"
 	"github.com/zhilyaev/helmwave/pkg/formatter"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 )
 
@@ -15,7 +16,11 @@ type Log struct {
 }
 
 func (c *Config) InitLogger() error {
-	// Override klog base logger to handle correctly log levels
+	// Skip various low-level k8s client errors
+	// There are a lot of context deadline errors being logged
+	utilruntime.ErrorHandlers = []func(error){
+		logKubernetesClientError,
+	}
 	klog.SetLogger(logrusr.NewLogger(log.StandardLogger()))
 
 	c.InitLoggerFormat()

--- a/pkg/helper/func.go
+++ b/pkg/helper/func.go
@@ -18,7 +18,7 @@ func TrimFirstRune(s string) string {
 }
 
 func CreateFile(p string) (*os.File, error) {
-	if err := os.MkdirAll(filepath.Dir(p), 0770); err != nil {
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
 		return nil, err
 	}
 	return os.Create(p)

--- a/pkg/helper/func.go
+++ b/pkg/helper/func.go
@@ -23,17 +23,3 @@ func CreateFile(p string) (*os.File, error) {
 	}
 	return os.Create(p)
 }
-
-func Save2File(p string, c string) error {
-	f, err := CreateFile(p)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.WriteString(c)
-	if err != nil {
-		return err
-	}
-
-	return f.Close()
-}

--- a/pkg/release/sync.go
+++ b/pkg/release/sync.go
@@ -65,7 +65,7 @@ func Sync(releases []*Config, manifestPath string, async bool) (err error) {
 	if async {
 		g := &parallel.Group{}
 		log.Debug("🐞 Run in parallel mode")
-		for i, _ := range releases {
+		for i := range releases {
 			g.Go(releases[i].SyncWithFails, &fails, manifestPath)
 		}
 		err := g.Wait()

--- a/pkg/repo/helm.go
+++ b/pkg/repo/helm.go
@@ -13,10 +13,16 @@ import (
 	"time"
 )
 
+const (
+	//flockTimeout is timeout for repo flock
+	flockTimeout = 30 * time.Second
+)
+
 func (rep *Config) Install(settings *helm.EnvSettings) error {
 	return Write(settings.RepositoryConfig, &rep.Entry, settings)
 }
 
+// Write updates given repository name if it exists in helm repository
 // TODO it better later
 func Write(repofile string, o *repo.Entry, helm *helm.EnvSettings) error {
 	//Ensure the file directory exists as it is required for file locking
@@ -25,20 +31,27 @@ func Write(repofile string, o *repo.Entry, helm *helm.EnvSettings) error {
 		return err
 	}
 
+	flockPath := strings.Replace(repofile, filepath.Ext(repofile), ".lock", 1)
 	// Acquire a file lock for process synchronization
-	fileLock := flock.New(strings.Replace(repofile, filepath.Ext(repofile), ".lock", 1))
-	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileLock := flock.New(flockPath)
+	lockCtx, cancel := context.WithTimeout(context.Background(), flockTimeout)
 	defer cancel()
 
 	locked, err := fileLock.TryLockContext(lockCtx, time.Second)
-	if err == nil && locked {
-		defer func(fileLock *flock.Flock) {
-			err := fileLock.Unlock()
-			if err != nil {
-				log.Errorf("Failed to release flock: %v", err.Error())
-			}
-		}(fileLock)
+	if err != nil {
+		log.Errorf("Failed to get flock: %v", err.Error())
+		return err
 	}
+	if !locked {
+		log.Errorf("Flock is not locked")
+	}
+
+	defer func(fileLock *flock.Flock) {
+		err := fileLock.Unlock()
+		if err != nil {
+			log.Errorf("Failed to release flock: %v", err.Error())
+		}
+	}(fileLock)
 
 	f, err := repo.LoadFile(repofile)
 	if err != nil {

--- a/pkg/repo/helm.go
+++ b/pkg/repo/helm.go
@@ -20,7 +20,7 @@ func (rep *Config) Install(settings *helm.EnvSettings) error {
 // TODO it better later
 func Write(repofile string, o *repo.Entry, helm *helm.EnvSettings) error {
 	//Ensure the file directory exists as it is required for file locking
-	err := os.MkdirAll(filepath.Dir(repofile), os.ModePerm)
+	err := os.MkdirAll(filepath.Dir(repofile), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}

--- a/pkg/yml/sync.go
+++ b/pkg/yml/sync.go
@@ -32,7 +32,7 @@ func (c *Config) Sync(manifestPath string, async bool, settings *helm.EnvSetting
 
 func (c *Config) SyncFake(manifestPath string, async bool, settings *helm.EnvSettings) error {
 	log.Info("🛫 Fake deploy")
-	for i, _ := range c.Releases {
+	for i := range c.Releases {
 		c.Releases[i].Options.DryRun = true
 	}
 	return c.Sync(manifestPath, async, settings)


### PR DESCRIPTION
* Style fixes for markdown and yaml (suggested by Goland)
* Use 0755 directory perms
* actually minor code refactor
* handle nasty reflector logs as debug logs:
```
[🤷 aka DEBUG]: kubernetes client error "pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1.Pod: failed to list *v1.Pod: context canceled"
[🙃 aka INFO]: Throttling request took 1.151597s, request: GET:https://172.22.4.111:5443/api/v1/namespaces/dev-test/pods?fieldSelector=metadata.name%3Dprod-backend-845db48d74-5bmsb&limit=500&resourceVersion=0
```